### PR TITLE
fix run.sh newline characters and give hints on installing dependencies

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# force .sh files to have /n newlines
+*.sh text eol=lf
+

--- a/SpaceInvadersDuel/run.sh
+++ b/SpaceInvadersDuel/run.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 
+# assumes mono and mono libraries are installed
+
+# on ubuntu you can install dependencies as follows:
+# sudo apt-get install mono-complete libnewtonsoft-json*
+
 mono SpaceInvadersDuel.exe $*


### PR DESCRIPTION
hi, 
I saw on the forums people had issues with this[1][2] and I experienced them on ubuntu too and the fixes worked for me too.

I followed this directions to fix the newline issue: https://help.github.com/articles/dealing-with-line-endings/
which requires you to do a `git reset --hard` to get it fixed on your system.
I think you should do that on the machine building the releases, but maybe test it out first on the side and check the newlines in a couple of files with something like notepad++:

![image](https://cloud.githubusercontent.com/assets/849576/7371524/d186ab70-edc1-11e4-9df5-662f425ff081.png)
![image](https://cloud.githubusercontent.com/assets/849576/7371530/df2b4a24-edc1-11e4-94d6-354cbf14d9e2.png)

[1] http://forum.entelect.co.za/thread/errors-building-testharness-on-unix/
[2] http://forum.entelect.co.za/thread/error-when-running-test-harness-on-linux/
