### PR TITLE
Prevent exception when bot process times-out

### DIFF
--- a/ChallengeHarness/Runners/BotRunner.cs
+++ b/ChallengeHarness/Runners/BotRunner.cs
@@ -205,7 +205,7 @@ namespace ChallengeHarness.Runners
                     _botTimer.ElapsedMilliseconds));
             }
 
-            if (p.ExitCode != 0)
+            if ((didExit) && (p.ExitCode != 0))
             {
                 OutputAppendLog(String.Format("[GAME]\tProcess exited with non-zero code {0} from player {1}.",
                     p.ExitCode, PlayerName));


### PR DESCRIPTION
This change prevents the exception "The process must exit before getting the requested information" that is thrown by the ExitCode property of the Process class.
