### PR TITLE
Prevent exception when trying to kill the bot process.

### DIFF
--- a/ChallengeHarness/Runners/BotRunner.cs
+++ b/ChallengeHarness/Runners/BotRunner.cs
@@ -194,7 +194,8 @@ namespace ChallengeHarness.Runners
 
             if (!didExit)
             {
-                p.Kill();
+                if (!p.HasExited)
+                    p.Kill();
                 OutputAppendLog(String.Format("[GAME]\tBot {0} timed out after {1} ms.", PlayerName,
                     _botTimer.ElapsedMilliseconds));
                 OutputAppendLog(String.Format("[GAME]\tKilled process {0}.", _processName));


### PR DESCRIPTION
This change prevents the exception "The process has already exited" that is thrown by the Kill() method of the Process class if the process had exited shortly after the WaitForExit() call.
