### PR TITLE
Corrects Alien shooting behavior

### DIFF
--- a/SpaceInvaders/Aliens/Strategies/ShootRandomlyStrategy.cs
+++ b/SpaceInvaders/Aliens/Strategies/ShootRandomlyStrategy.cs
@@ -7,8 +7,6 @@ namespace SpaceInvaders.Aliens.Strategies
 {
     public class ShootRandomlyStrategy : IShootStrategy
     {
-        private readonly Random _rng = new Random();
-
         public ShootRandomlyStrategy(List<List<Alien>> waves)
         {
             Waves = waves;
@@ -20,7 +18,7 @@ namespace SpaceInvaders.Aliens.Strategies
         {
             var aliens = FindAliensThatCanShootSafely();
 
-            return aliens.Count == 0 ? null : aliens[_rng.Next(0, aliens.Count)];
+            return aliens.Count == 0 ? null : aliens[StaticRandom.Next(0, aliens.Count)];
         }
 
         public Alien SelectShootingAlienExcludingAliens(Entity target, List<Alien> excludedAliens)
@@ -31,7 +29,7 @@ namespace SpaceInvaders.Aliens.Strategies
                 aliens.Remove(alien);
             }
 
-            return aliens.Count == 0 ? null : aliens[_rng.Next(0, aliens.Count)];
+            return aliens.Count == 0 ? null : aliens[StaticRandom.Next(0, aliens.Count)];
         }
 
         private List<Alien> FindAliensThatCanShootSafely()

--- a/SpaceInvaders/Aliens/Strategies/ShootUsingRandomStrategy.cs
+++ b/SpaceInvaders/Aliens/Strategies/ShootUsingRandomStrategy.cs
@@ -64,7 +64,6 @@ namespace SpaceInvaders.Aliens.Strategies
     {
         private readonly int _chancesForFirstStrategy;
         private readonly int _chancesForSecondStrategy;
-        private readonly Random _rng = new Random();
 
         public RandomStrategySelector(int chancesForFirstStrategy, int chancesForSecondStrategy)
         {
@@ -74,7 +73,7 @@ namespace SpaceInvaders.Aliens.Strategies
 
         public bool UseFirstStrategy()
         {
-            return _rng.Next(0, _chancesForFirstStrategy + _chancesForSecondStrategy) < _chancesForFirstStrategy;
+            return StaticRandom.Next(0, _chancesForFirstStrategy + _chancesForSecondStrategy) < _chancesForFirstStrategy;
         }
     }
 }

--- a/SpaceInvaders/Core/StaticRandom.cs
+++ b/SpaceInvaders/Core/StaticRandom.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SpaceInvaders.Core
+{
+    public static class StaticRandom
+    {
+        private static readonly Random _random = new Random();
+
+        public static int Next(int minValue, int maxValue)
+        {
+            return _random.Next(minValue, maxValue);
+        }
+    }
+}

--- a/SpaceInvaders/SpaceInvaders.csproj
+++ b/SpaceInvaders/SpaceInvaders.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -62,6 +62,7 @@
     <Compile Include="Core\Map.cs" />
     <Compile Include="Core\MapAction.cs" />
     <Compile Include="Core\Player.cs" />
+    <Compile Include="Core\StaticRandom.cs" />
     <Compile Include="Core\UpdateManager.cs" />
     <Compile Include="Entities\Alien.cs" />
     <Compile Include="Entities\Buildings\AlienFactory.cs" />


### PR DESCRIPTION
The current Alien behavior differs from the intended Alien behavior.
Alien shooting behavior should be random, but instead aliens mirror each other.

The random class relies on the system clock for its seed value. Because both instances of Random are instantiated within 15ms they are seeded to the same value. The  "random" values generated therefor are not random, but the same for both objects.

The fix creates a single static instance of the Random class, which is only seeded once. All calls made from the static "Next" method, will be properly random. 
