### PR TITLE
Fix: Players start with 2 lives instead of 3

### DIFF
--- a/SpaceInvaders/Core/Player.cs
+++ b/SpaceInvaders/Core/Player.cs
@@ -103,7 +103,8 @@ namespace SpaceInvaders.Core
 
             try
             {
-            	Lives--;
+                if (Match.GetInstance().GetRoundNumber() > 0)
+            	    Lives--;
                 map.AddEntity(ship);
                 Ship = ship;
             }


### PR DESCRIPTION
On initial respawn of a player, its life is chawed for no reason.
