### PR TITLE
Fixed missile collision bug.

### DIFF
--- a/SpaceInvaders/Core/Entity.cs
+++ b/SpaceInvaders/Core/Entity.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using SpaceInvaders.Exceptions;
+using System.Collections.Generic;
 
 namespace SpaceInvaders.Core
 {

--- a/SpaceInvaders/Core/Entity.cs
+++ b/SpaceInvaders/Core/Entity.cs
@@ -53,6 +53,11 @@ namespace SpaceInvaders.Core
         {
         }
 
+        public virtual void PreUpdate()
+        {
+
+        }
+
         protected Player GetPlayer()
         {
             return Match.GetInstance().GetPlayer(PlayerNumber);

--- a/SpaceInvaders/Core/Map.cs
+++ b/SpaceInvaders/Core/Map.cs
@@ -201,7 +201,7 @@ namespace SpaceInvaders.Core
         {
             CheckBounds(targetX, targetY);
             CheckBounds(targetX + entity.Width - 1, targetY + entity.Height - 1);
-
+            List<Entity> collisions = new List<Entity>();
             for (var x = targetX; x < targetX + entity.Width; x++)
             {
                 for (var y = targetY; y < targetY + entity.Height; y++)
@@ -212,7 +212,8 @@ namespace SpaceInvaders.Core
                             var mapEntity = GetEntity(x, y);
                             if (mapEntity != null)
                             {
-                                throw new CollisionException {Entity = mapEntity};
+                                //store all collisions and then decide what to do with them
+                                collisions.Add(mapEntity);
                             }
                             break;
                         case MapAction.Add:
@@ -223,6 +224,10 @@ namespace SpaceInvaders.Core
                             break;
                     }
                 }
+            }
+            if (collisions.Count > 0)
+            {
+                throw new CollisionException {Entities = collisions, Entity = collisions[0]};
             }
         }
 

--- a/SpaceInvaders/Core/Map.cs
+++ b/SpaceInvaders/Core/Map.cs
@@ -175,6 +175,11 @@ namespace SpaceInvaders.Core
             TraverseMap(MapAction.Remove, entity, entity.X, entity.Y);
         }
 
+        public void ClearEntity(Entity entity)
+        {
+            TraverseMap(MapAction.Remove, entity, entity.X, entity.Y);
+        }
+
         public void MoveEntity(Entity entity, int x, int y)
         {
             TraverseMap(MapAction.Remove, entity, entity.X, entity.Y);
@@ -220,7 +225,10 @@ namespace SpaceInvaders.Core
                             Rows[y][x] = entity;
                             break;
                         case MapAction.Remove:
-                            Rows[y][x] = null;
+                            if (Rows[y][x] == entity)
+                            {
+                                Rows[y][x] = null;
+                            }   
                             break;
                     }
                 }

--- a/SpaceInvaders/Core/Player.cs
+++ b/SpaceInvaders/Core/Player.cs
@@ -109,16 +109,19 @@ namespace SpaceInvaders.Core
             }
             catch (CollisionException e)
             {
-                if (e.Entity.GetType() == typeof (Missile))
+                foreach (Entity entity in e.Entities) 
                 {
-                    ((Missile) e.Entity).ScoreKill(ship);
-                    e.Entity.Destroy();
-                    ship.Destroy();
-                }
-                else if (e.Entity.GetType() == typeof (Alien) || e.Entity.GetType() == typeof (Bullet))
-                {
-                    e.Entity.Destroy();
-                    ship.Destroy();
+                    if (entity.GetType() == typeof (Missile))
+                    {
+                        ((Missile) entity).ScoreKill(ship);
+                        entity.Destroy();
+                        ship.Destroy();
+                    }
+                    else if (entity.GetType() == typeof (Alien) || entity.GetType() == typeof (Bullet))
+                    {
+                        entity.Destroy();
+                        ship.Destroy();
+                    }
                 }
             }
         }

--- a/SpaceInvaders/Core/UpdateManager.cs
+++ b/SpaceInvaders/Core/UpdateManager.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using SpaceInvaders.Exceptions;
 
 namespace SpaceInvaders.Core
 {
@@ -62,6 +63,7 @@ namespace SpaceInvaders.Core
 
         private void UpdateEntityGroup(EntityType type)
         {
+            List<Entity> collided = new List<Entity>();
             for (var playerNumber = 1; playerNumber <= 2; playerNumber++)
             {
                 if ((!Entities.ContainsKey(playerNumber)) || (!Entities[playerNumber].ContainsKey(type)))
@@ -71,9 +73,23 @@ namespace SpaceInvaders.Core
                 {
                     if (entity.Alive)
                     {
-                        entity.Update();
+                        try
+                        {
+                            entity.Update();
+                        }
+                        catch (CollisionException e)
+                        {
+                            collided.Add(entity);
+                            collided.AddRange(e.Entities);
+                        }
                     }
                 }
+            }
+            //after all the updates have taken place for this entity type, then remove destroyed entities
+            //only destroy the entities that don't deal with their own CollisionExceptions like Missile and Bullet
+            foreach (Entity e in collided)
+            {
+                e.Destroy();
             }
         }
 

--- a/SpaceInvaders/Core/UpdateManager.cs
+++ b/SpaceInvaders/Core/UpdateManager.cs
@@ -71,6 +71,24 @@ namespace SpaceInvaders.Core
 
                 foreach (var entity in Entities[playerNumber][type])
                 {
+                    try
+                    {
+                        entity.PreUpdate(); //in the case of a missile will throw an exception if the missile will pass through another one
+                    }
+                    catch (CollisionException e)
+                    {
+                        collided.Add(entity);
+                        collided.AddRange(e.Entities);
+                    }
+                }
+            }
+            for (var playerNumber = 1; playerNumber <= 2; playerNumber++)
+            {
+                if ((!Entities.ContainsKey(playerNumber)) || (!Entities[playerNumber].ContainsKey(type)))
+                    continue;
+
+                foreach (var entity in Entities[playerNumber][type])
+                {
                     if (entity.Alive)
                     {
                         try

--- a/SpaceInvaders/Entities/Bullet.cs
+++ b/SpaceInvaders/Entities/Bullet.cs
@@ -50,8 +50,12 @@ namespace SpaceInvaders.Entities
             }
             catch (CollisionException e)
             {
-                e.Entity.Destroy();
-                Destroy();
+                //throw the exception so that this bullet and the entity it destroyed can be removed at an appropriate time (not mid-update).
+                //This deals with the case where multiple bullets hit a building or ship simultaneously. 
+                //The ship will only be removed after all the bullets have been moved.
+                throw e;
+                //e.Entity.Destroy();
+                //Destroy();
             }
         }
 

--- a/SpaceInvaders/Entities/Missile.cs
+++ b/SpaceInvaders/Entities/Missile.cs
@@ -53,9 +53,10 @@ namespace SpaceInvaders.Entities
             catch (CollisionException e)
             {
                 ScoreKill(e.Entity);
-
-                e.Entity.Destroy();
-                Destroy();
+                //throw the exception so that this missile and the entity it destroyed can be removed at an appropriate time (not mid-update).
+                throw e;
+                //e.Entity.Destroy();
+                //Destroy();
             }
         }
 

--- a/SpaceInvaders/Entities/Missile.cs
+++ b/SpaceInvaders/Entities/Missile.cs
@@ -43,21 +43,49 @@ namespace SpaceInvaders.Entities
             return copy;
         }
 
+        public override void PreUpdate()
+        {
+            GetMap().ClearEntity(this);
+            CheckNextPosition(); //checks this missile's next position for an opponent's missile
+            //The first of the two missiles to be cleared will detect the other and throw a collision exception.
+        }
+
         public override void Update()
         {
             var deltaY = (PlayerNumber == 1 ? -1 : 1);
             try
             {
-                GetMap().MoveEntity(this, X, Y + deltaY);
+                //GetMap().MoveEntity(this, X, Y + deltaY);
+                this.X = X;
+                this.Y = Y + deltaY;
+                GetMap().AddEntity(this);
+                //check where the missile was for a missile owned by the other player. If there is one, they must've passed through each other
             }
             catch (CollisionException e)
             {
                 ScoreKill(e.Entity);
                 //throw the exception so that this missile and the entity it destroyed can be removed at an appropriate time (not mid-update).
                 throw e;
-                //e.Entity.Destroy();
-                //Destroy();
             }
+        }
+
+        public void CheckNextPosition()
+        {
+            var deltaY = (PlayerNumber == 1 ? -1 : 1);
+                            Entity next = GetMap().GetEntity(X, Y + deltaY);
+                if (next != null)
+                {
+                    if (next.PlayerNumber != this.PlayerNumber)
+                    {
+                        if (next.GetType() == typeof(Missile))
+                        {
+                                        List<Entity> collisions = new List<Entity>();
+                            collisions.Add(this);
+                            collisions.Add(next);
+                            throw new CollisionException() { Entity = this, Entities = collisions };
+                        }
+                    }
+                }
         }
 
         public void ScoreKill(Entity entity)

--- a/SpaceInvaders/Entities/Ship.cs
+++ b/SpaceInvaders/Entities/Ship.cs
@@ -101,7 +101,31 @@ namespace SpaceInvaders.Entities
 
         public override void Update()
         {
-            ProcessCommand();
+            try
+            {
+                ProcessCommand();
+            }
+            catch (CollisionException e)
+            {
+                //if the ship moved and caused a collision exception, if it didn't collide with wall it should be destroyed.
+                if (e.Entity.GetType() != typeof (Wall))
+                {
+                    foreach (Entity entity in e.Entities)
+                    {
+                        if (e.Entity.GetType() == typeof(Missile))
+                        {
+                            Missile m = (Missile)entity;
+                            m.ScoreKill(this);
+                            m.Destroy();
+                        }
+                        else
+                        {
+                            entity.Destroy();
+                        }
+                    }
+                    this.Destroy();
+                }
+            }
         }
 
         private void ProcessCommand()
@@ -117,13 +141,15 @@ namespace SpaceInvaders.Entities
                         var deltaX = PlayerNumber == 1 ? -1 : 1;
                         GetMap().MoveEntity(this, X + deltaX, Y);
                     }
-                    catch (CollisionException)
+                    catch (CollisionException e)
                     {
-                        CommandFeedback = "Tried to move left, but collided with something.";
+                        CommandFeedback = "Moved left and collided with " + e.Entity.GetType();
+                        throw e;
                     }
                     catch (MoveNotOnMapException)
                     {
-                        CommandFeedback = "Tried to move left, but collided with something.";
+                        //this should be impossible since a wall is an entity and causes a collision exception
+                        CommandFeedback = "Tried to move left, but collided with the wall.";
                     }
                     break;
                 case ShipCommand.MoveRight:
@@ -133,13 +159,15 @@ namespace SpaceInvaders.Entities
                         var deltaX = PlayerNumber == 1 ? 1 : -1;
                         GetMap().MoveEntity(this, X + deltaX, Y);
                     }
-                    catch (CollisionException)
+                    catch (CollisionException e)
                     {
-                        CommandFeedback = "Tried to move right, but collided with something.";
+                        CommandFeedback = "Moved right and collided with " + e.Entity.GetType();
+                        throw e;
                     }
                     catch (MoveNotOnMapException)
                     {
-                        CommandFeedback = "Tried to move right, but collided with something.";
+                        //this should be impossible since a wall is an entity and causes a collision exception
+                        CommandFeedback = "Tried to move right, but collided with the wall.";
                     }
                     break;
                 case ShipCommand.Shoot:

--- a/SpaceInvaders/Exceptions/CollisionException.cs
+++ b/SpaceInvaders/Exceptions/CollisionException.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using SpaceInvaders.Core;
+using System.Collections.Generic;
 
 namespace SpaceInvaders.Exceptions
 {
     public class CollisionException : Exception
     {
         public Entity Entity { get; set; }
+        public List<Entity> Entities { get; set; }
     }
 }

--- a/SpaceInvadersTest/Tests/ShipTest.cs
+++ b/SpaceInvadersTest/Tests/ShipTest.cs
@@ -868,6 +868,105 @@ namespace SpaceInvadersTest.Tests
             Assert.IsTrue(finalScore == initialScore, "Player 2 increased.");
         }
 
+        [Test]
+        public void TestBuildingOnBullets()
+        {
+            // Given
+            var game = Match.GetInstance();
+            game.StartNewGame();
+
+            var player = game.GetPlayer(1);
+            var ship = player.Ship;
+            var map = game.Map;
+            var player2 = game.GetPlayer(2);
+
+            // When
+            //destroy ship so that bullet can pass through it just before it respawns
+            ship.Destroy();
+
+            var bullet = new Bullet(2) { X = ship.X, Y = ship.Y - 2 }; //left side of ship
+            map.AddEntity(bullet);
+
+
+            for (var i = 0; i < respawnDelay-1; i++)
+            {
+                game.Update();
+            }
+            ship.Command = ShipCommand.BuildMissileController;
+            game.Update();
+
+            // Then
+            Assert.IsTrue(bullet.Alive, "Bullet was destroyed. Should've remained.");
+            Assert.IsTrue(player.Lives == 1, "Player should be on 1 life after respawning.");
+            Assert.IsTrue(player.MissileController == null, "Missile controller should not have been built.");
+
+        }
+
+        [Test]
+        public void TestBuildingOnAliens()
+        {
+            // Given
+            var game = Match.GetInstance();
+            game.StartNewGame();
+
+            var player = game.GetPlayer(1);
+            var ship = player.Ship;
+            var map = game.Map;
+            var player2 = game.GetPlayer(2);
+            var aliens = player2.AlienManager;
+
+            // When
+            ship.Destroy();
+
+            var alien = aliens.TestAddAlien(ship.X - 1, ship.Y - 2);
+            aliens.TestMakeAllAliensMoveForward();
+
+
+            for (var i = 0; i < respawnDelay - 1; i++)
+            {
+                game.Update();
+            }
+            ship.Command = ShipCommand.BuildAlienFactory;
+            game.Update();
+
+            // Then
+            Assert.IsTrue(alien.Alive, "Alien was destroyed. Should've remained.");
+            Assert.IsTrue(player.Lives == 1, "Player should be on 1 life after respawning.");
+            Assert.IsTrue(player.AlienFactory == null, "Alien factory should not have been built.");
+        }
+
+        [Test]
+        public void TestBuildingOnMissile()
+        {
+            // Given
+            var game = Match.GetInstance();
+            game.StartNewGame();
+
+            var player = game.GetPlayer(1);
+            var ship = player.Ship;
+            var map = game.Map;
+            var player2 = game.GetPlayer(2);
+            var aliens = player2.AlienManager;
+
+            // When
+            ship.Destroy();
+
+            var missile = new Missile(2) { X = ship.X, Y = ship.Y - 2 };
+            map.AddEntity(missile);
+
+            for (var i = 0; i < respawnDelay - 1; i++)
+            {
+                game.Update();
+            }
+            ship.Command = ShipCommand.BuildAlienFactory;
+            game.Update();
+
+            // Then
+            Assert.IsTrue(missile.Alive, "Missile was destroyed. Should've remained.");
+            Assert.IsTrue(player.Lives == 1, "Player should be on 1 life after respawning.");
+            Assert.IsTrue(player.AlienFactory == null, "Alien factory should not have been built.");
+        }
+
         /**
          * This may be testing a case which is impossible. In order for 2 alien bullets to be in the same row, 
          * they need to be fired by aliens in different rows. This can only happen when spawn energy is high 

--- a/SpaceInvadersTest/Tests/ShipTest.cs
+++ b/SpaceInvadersTest/Tests/ShipTest.cs
@@ -868,39 +868,7 @@ namespace SpaceInvadersTest.Tests
             Assert.IsTrue(finalScore == initialScore, "Player 2 increased.");
         }
 
-        [Test]
-        public void TestBuildingOnBullets()
-        {
-            // Given
-            var game = Match.GetInstance();
-            game.StartNewGame();
 
-            var player = game.GetPlayer(1);
-            var ship = player.Ship;
-            var map = game.Map;
-            var player2 = game.GetPlayer(2);
-
-            // When
-            //destroy ship so that bullet can pass through it just before it respawns
-            ship.Destroy();
-
-            var bullet = new Bullet(2) { X = ship.X, Y = ship.Y - 2 }; //left side of ship
-            map.AddEntity(bullet);
-
-
-            for (var i = 0; i < respawnDelay-1; i++)
-            {
-                game.Update();
-            }
-            ship.Command = ShipCommand.BuildMissileController;
-            game.Update();
-
-            // Then
-            Assert.IsTrue(bullet.Alive, "Bullet was destroyed. Should've remained.");
-            Assert.IsTrue(player.Lives == 1, "Player should be on 1 life after respawning.");
-            Assert.IsTrue(player.MissileController == null, "Missile controller should not have been built.");
-
-        }
 
         [Test]
         public void TestBuildingOnAliens()
@@ -916,56 +884,19 @@ namespace SpaceInvadersTest.Tests
             var aliens = player2.AlienManager;
 
             // When
-            ship.Destroy();
 
-            var alien = aliens.TestAddAlien(ship.X - 1, ship.Y - 2);
-            aliens.TestMakeAllAliensMoveForward();
+            var alien = aliens.TestAddAlien(ship.X + 3, ship.Y + 1);
+            alien.DeltaX = -1;
 
-
-            for (var i = 0; i < respawnDelay - 1; i++)
-            {
-                game.Update();
-            }
             ship.Command = ShipCommand.BuildAlienFactory;
             game.Update();
 
             // Then
             Assert.IsTrue(alien.Alive, "Alien was destroyed. Should've remained.");
-            Assert.IsTrue(player.Lives == 1, "Player should be on 1 life after respawning.");
+            Assert.IsTrue(player.Lives == 2, "Player should be on 2 lives.");
             Assert.IsTrue(player.AlienFactory == null, "Alien factory should not have been built.");
         }
 
-        [Test]
-        public void TestBuildingOnMissile()
-        {
-            // Given
-            var game = Match.GetInstance();
-            game.StartNewGame();
-
-            var player = game.GetPlayer(1);
-            var ship = player.Ship;
-            var map = game.Map;
-            var player2 = game.GetPlayer(2);
-            var aliens = player2.AlienManager;
-
-            // When
-            ship.Destroy();
-
-            var missile = new Missile(2) { X = ship.X, Y = ship.Y - 2 };
-            map.AddEntity(missile);
-
-            for (var i = 0; i < respawnDelay - 1; i++)
-            {
-                game.Update();
-            }
-            ship.Command = ShipCommand.BuildAlienFactory;
-            game.Update();
-
-            // Then
-            Assert.IsTrue(missile.Alive, "Missile was destroyed. Should've remained.");
-            Assert.IsTrue(player.Lives == 1, "Player should be on 1 life after respawning.");
-            Assert.IsTrue(player.AlienFactory == null, "Alien factory should not have been built.");
-        }
 
         /**
          * This may be testing a case which is impossible. In order for 2 alien bullets to be in the same row, 

--- a/SpaceInvadersTest/Tests/ShipTest.cs
+++ b/SpaceInvadersTest/Tests/ShipTest.cs
@@ -585,6 +585,160 @@ namespace SpaceInvadersTest.Tests
         }
 
         [Test]
+        public void TestShipMovingLeftIntoMissileDies()
+        {
+            // Given
+            var game = Match.GetInstance();
+            game.StartNewGame();
+            var map = game.Map;
+
+            var player = game.GetPlayer(1);
+            var ship = player.Ship;
+            var aliens = game.GetPlayer(2).AlienManager;
+            var player2 = game.GetPlayer(2);
+            var killsBefore = player2.Kills;
+
+            // When
+            var missile = new Missile(2) { X = ship.X - 1, Y = ship.Y - 1 };
+            map.AddEntity(missile);
+
+            ship.Command = ShipCommand.MoveLeft;
+            game.Update();
+
+
+            // Then
+            var killsAfter = player2.Kills;
+            Assert.IsFalse(missile.Alive, "Missile was not destroyed, must've mis-timed the collision.");
+            Assert.IsNull(player.Ship, "Ship was not destroyed.");
+            Assert.IsTrue(killsAfter == killsBefore + 1, "Player 2 did not get the kill.");
+        }
+
+        [Test]
+        public void TestShipMovingRightIntoMissileDies()
+        {
+            // Given
+            var game = Match.GetInstance();
+            game.StartNewGame();
+            var map = game.Map;
+
+            var player = game.GetPlayer(1);
+            var ship = player.Ship;
+            var aliens = game.GetPlayer(2).AlienManager;
+            var player2 = game.GetPlayer(2);
+            var killsBefore = player2.Kills;
+
+            // When
+            var missile = new Missile(2) { X = ship.X + 3, Y = ship.Y - 1 };
+            map.AddEntity(missile);
+
+            ship.Command = ShipCommand.MoveRight;
+            game.Update();
+
+
+            // Then
+            var killsAfter = player2.Kills;
+            Assert.IsFalse(missile.Alive, "Missile was not destroyed, must've mis-timed the collision.");
+            Assert.IsNull(player.Ship, "Ship was not destroyed.");
+            Assert.IsTrue(killsAfter == killsBefore + 1, "Player 2 did not get the kill.");
+        }
+
+        [Test]
+        public void TestShipMovingLeftIntoBulletDies()
+        {
+            // Given
+            var game = Match.GetInstance();
+            game.StartNewGame();
+            var map = game.Map;
+
+            var player = game.GetPlayer(1);
+            var ship = player.Ship;
+            var aliens = game.GetPlayer(2).AlienManager;
+
+            // When
+            var bullet = new Bullet(2) { X = ship.X -1, Y = ship.Y - 1 };
+            map.AddEntity(bullet);
+
+            ship.Command = ShipCommand.MoveLeft;
+            game.Update();
+
+
+            // Then
+            Assert.IsFalse(bullet.Alive, "Bullet was not destroyed, must've mis-timed the collision.");
+            Assert.IsNull(player.Ship, "Ship was not destroyed.");
+        }
+
+        [Test]
+        public void TestShipMovingRightIntoBulletDies()
+        {
+            // Given
+            var game = Match.GetInstance();
+            game.StartNewGame();
+            var map = game.Map;
+
+            var player = game.GetPlayer(1);
+            var ship = player.Ship;
+            var aliens = game.GetPlayer(2).AlienManager;
+
+            // When
+            var bullet = new Bullet(2) { X = ship.X + 3, Y = ship.Y - 1 };
+            map.AddEntity(bullet);
+
+            ship.Command = ShipCommand.MoveRight;
+            game.Update();
+
+
+            // Then
+            Assert.IsFalse(bullet.Alive, "Bullet was not destroyed, must've mis-timed the collision.");
+            Assert.IsNull(player.Ship, "Ship was not destroyed.");
+        }
+
+        [Test]
+        public void TestShipMovingLeftIntoAlienDies()
+        {
+            // Given
+            var game = Match.GetInstance();
+            game.StartNewGame();
+
+            var player = game.GetPlayer(1);
+            var ship = player.Ship;
+            var aliens = game.GetPlayer(2).AlienManager;
+
+            // When
+            var alien = aliens.TestAddAlien(ship.X - 1, ship.Y - 1);
+            aliens.TestMakeAllAliensMoveForward();
+            ship.Command = ShipCommand.MoveLeft;
+            game.Update();
+            
+
+            // Then
+            Assert.IsFalse(alien.Alive, "Alien was not destroyed, must've mis-timed the collision.");
+            Assert.IsNull(player.Ship, "Ship was not destroyed.");
+        }
+
+        [Test]
+        public void TestShipMovingRightIntoAlienDies()
+        {
+            // Given
+            var game = Match.GetInstance();
+            game.StartNewGame();
+
+            var player = game.GetPlayer(1);
+            var ship = player.Ship;
+            var aliens = game.GetPlayer(2).AlienManager;
+
+            // When
+            var alien = aliens.TestAddAlien(ship.X +3 , ship.Y - 1);
+            aliens.TestMakeAllAliensMoveForward();
+            ship.Command = ShipCommand.MoveRight;
+            game.Update();
+
+
+            // Then
+            Assert.IsFalse(alien.Alive, "Alien was not destroyed, must've mis-timed the collision.");
+            Assert.IsNull(player.Ship, "Ship was not destroyed.");
+        }
+
+        [Test]
         public void TestShipSpawningOnAlienDies()
         {
             // Given

--- a/SpaceInvadersTest/Tests/ShipTest.cs
+++ b/SpaceInvadersTest/Tests/ShipTest.cs
@@ -329,6 +329,83 @@ namespace SpaceInvadersTest.Tests
         }
 
         [Test]
+        public void TestTwoMissileShieldCollission()
+        {
+            // Given
+            var game = Match.GetInstance();
+            game.StartNewGame(true);
+            var map = game.Map;
+            var player = game.GetPlayer(1);
+            var ship = player.Ship;
+
+            ship.Command = ShipCommand.BuildShield;
+            game.Update();
+
+            // When
+            //destroy closest shield
+            ship.Command = ShipCommand.Shoot;
+            game.Update();
+
+            //destroy second closest shield
+            ship.Command = ShipCommand.Shoot;
+            game.Update(); 
+            game.Update();
+
+
+            var missile2 = new Missile(2) { X = ship.X+1, Y = ship.Y - 5}; //place missile so that player 1's missile and player 2's missile collide on a shield
+            var missile1 = new Missile(1) { X = ship.X + 1, Y = ship.Y - 1 };
+            map.AddEntity(missile1);
+            map.AddEntity(missile2);
+            //fire at 3rd closest shield
+            game.Update();
+            game.Update();
+
+            // Then
+            Assert.IsNull(map.GetEntity(ship.X + 1, ship.Y - 1),
+                "Center shield tile was not destroyed");
+            Assert.IsNull(map.GetEntity(ship.X + 1, ship.Y - 2),
+                "Second centre shield tile was not destroyed");
+            Assert.IsNull(map.GetEntity(ship.X + 1, ship.Y - 2),
+                "Third centre shield tile was not destroyed");
+            Assert.IsFalse(missile1.Alive, "Missile was not destroyed, must've mis-timed the collision.");
+            Assert.IsFalse(missile2.Alive, "Missile was not destroyed, must've mis-timed the collision.");
+        }
+
+        [Test]
+        public void TestTwoMissileAlienCollission()
+        {
+            // Given
+            var game = Match.GetInstance();
+            game.StartNewGame(true);
+            var map = game.Map;
+            var player = game.GetPlayer(1);
+            var ship = player.Ship;
+            var aliens = game.GetPlayer(2).AlienManager;
+            var player1 = game.GetPlayer(1);
+            var initialScore = player1.Kills;
+
+
+            // When
+            var missile2 = new Missile(2) { X = ship.X + 1, Y = ship.Y - 4 }; 
+            var missile1 = new Missile(1) { X = ship.X + 1, Y = ship.Y - 2 };
+            map.AddEntity(missile1);
+            map.AddEntity(missile2);
+            var alien = aliens.TestAddAlien(ship.X + 1, ship.Y - 3); 
+
+            game.Update();
+
+            var finalScore = player1.Kills;
+
+            // Then
+            Assert.IsFalse(alien.Alive, "Alien was not destroyed, must've mis-timed the collision.");
+            Assert.IsTrue(finalScore == initialScore+1, "Player 1 score did not increase.");
+
+            // Then
+            Assert.IsFalse(missile1.Alive, "Player 1's missile was not destroyed, must've mis-timed the collision.");
+            Assert.IsFalse(missile2.Alive, "Player 2's missile was not destroyed, must've mis-timed the collision.");
+        }
+
+        [Test]
         public void TestMissileDestroyingShip()
         {
             // Given
@@ -559,6 +636,125 @@ namespace SpaceInvadersTest.Tests
             Assert.IsFalse(missile.Alive, "Missile was not destroyed, must've mis-timed the collision.");
             Assert.IsNull(player1.Ship, "Player 1 ship was not destroyed.");
             Assert.IsTrue(finalScore > initialScore, "Player 2 score did not increase.");
+        }
+
+        [Test]
+        public void TestShipSpawningOnMultipleEntitiesDie()
+        {
+            // Given
+            var game = Match.GetInstance();
+            game.StartNewGame();
+
+            var player = game.GetPlayer(1);
+            var ship = player.Ship;
+            var aliens = game.GetPlayer(2).AlienManager;
+            var map = game.Map;
+            var player2 = game.GetPlayer(2);
+            var initialScore = player2.Kills;
+
+            // When
+            var alien = aliens.TestAddAlien(ship.X, ship.Y - 3); //left side of ship
+            aliens.TestMakeAllAliensMoveForward();
+            ship.Destroy();
+            var missile = new Missile(2) { X = ship.X + 1, Y = ship.Y - 3 }; //centre of ship
+            map.AddEntity(missile);
+
+            var bullet = new Bullet(2) { X = ship.X + 2, Y = ship.Y - 3 }; //right side of ship
+            map.AddEntity(bullet);
+
+            for (var i = 0; i < respawnDelay; i++)
+            {
+                game.Update();
+            }
+            var finalScore = player2.Kills;
+
+            // Then
+            Assert.IsFalse(alien.Alive, "Alien was not destroyed, must've mis-timed the collision.");
+            Assert.IsNull(player.Ship, "Ship was not destroyed.");
+            Assert.IsFalse(missile.Alive, "Missile was not destroyed, must've mis-timed the collision.");
+            Assert.IsFalse(bullet.Alive, "Bullet was not destroyed, must've mis-timed the collision.");
+            Assert.IsTrue(finalScore > initialScore, "Player 2 score did not increase.");
+        }
+
+        [Test]
+        public void TestShipSpawningOnMultipleBulletsDie()
+        {
+            // Given
+            var game = Match.GetInstance();
+            game.StartNewGame();
+
+            var player = game.GetPlayer(1);
+            var ship = player.Ship;
+            var map = game.Map;
+            var player2 = game.GetPlayer(2);
+            var initialScore = player2.Kills;
+
+            // When
+            ship.Destroy();
+
+            var bullet1 = new Bullet(2) { X = ship.X, Y = ship.Y - 3 }; //left side of ship
+            map.AddEntity(bullet1);
+            var bullet2 = new Bullet(2) { X = ship.X + 1, Y = ship.Y - 3 }; //centre of ship
+            map.AddEntity(bullet2);
+            var bullet3 = new Bullet(2) { X = ship.X + 2, Y = ship.Y - 3 }; //right side of ship
+            map.AddEntity(bullet3);
+
+
+            for (var i = 0; i < respawnDelay; i++)
+            {
+                game.Update();
+            }
+            var finalScore = player2.Kills;
+
+            // Then
+            Assert.IsNull(player.Ship, "Ship was not destroyed.");
+            Assert.IsFalse(bullet1.Alive, "Bullet was not destroyed, must've mis-timed the collision.");
+            Assert.IsFalse(bullet2.Alive, "Bullet was not destroyed, must've mis-timed the collision.");
+            Assert.IsFalse(bullet3.Alive, "Bullet was not destroyed, must've mis-timed the collision.");
+            Assert.IsTrue(finalScore == initialScore, "Player 2 increased.");
+        }
+
+        /**
+         * This may be testing a case which is impossible. In order for 2 alien bullets to be in the same row, 
+         * they need to be fired by aliens in different rows. This can only happen when spawn energy is high 
+         * enough, say 10. An alien in the second row fires, and 2 turns later an alien in the front row fires. 
+         * Those bullets also have to be close enough on the x axis to hit a ship at the same time.
+         */
+        [Test]
+        public void TestMultipleBulletsKillShip()
+        {
+            // Given
+            var game = Match.GetInstance();
+            game.StartNewGame();
+
+            var player = game.GetPlayer(1);
+            var ship = player.Ship;
+            var map = game.Map;
+            var player2 = game.GetPlayer(2);
+            var initialScore = player2.Kills;
+
+            // When
+
+            var bullet1 = new Bullet(2) { X = ship.X, Y = ship.Y - 3 }; //left side of ship
+            map.AddEntity(bullet1);
+            var bullet2 = new Bullet(2) { X = ship.X + 1, Y = ship.Y - 3 }; //centre of ship
+            map.AddEntity(bullet2);
+            var bullet3 = new Bullet(2) { X = ship.X + 2, Y = ship.Y - 3 }; //right side of ship
+            map.AddEntity(bullet3);
+
+
+            for (var i = 0; i < respawnDelay; i++)
+            {
+                game.Update();
+            }
+            var finalScore = player2.Kills;
+
+            // Then
+            Assert.IsNull(player.Ship, "Ship was not destroyed.");
+            Assert.IsFalse(bullet1.Alive, "Bullet was not destroyed, must've mis-timed the collision.");
+            Assert.IsFalse(bullet2.Alive, "Bullet was not destroyed, must've mis-timed the collision.");
+            Assert.IsFalse(bullet3.Alive, "Bullet was not destroyed, must've mis-timed the collision.");
+            Assert.IsTrue(finalScore == initialScore, "Player 2 increased.");
         }
 
         [Test]

--- a/SpaceInvadersTest/Tests/ShipTest.cs
+++ b/SpaceInvadersTest/Tests/ShipTest.cs
@@ -643,6 +643,182 @@ namespace SpaceInvadersTest.Tests
         }
 
         [Test]
+        public void TestSamePlayerMissilesDontDestroyEachother1()
+        {
+            // Given
+            var game = Match.GetInstance();
+            game.StartNewGame();
+            var map = game.Map;
+
+            var player = game.GetPlayer(1);
+            var ship = player.Ship;
+            var aliens = game.GetPlayer(2).AlienManager;
+            var player2 = game.GetPlayer(2);
+            var killsBefore = player2.Kills;
+
+            // When
+            //add them in the order the harness would add them
+            var missile1 = new Missile(1) { X = ship.X, Y = ship.Y - 2 };
+            map.AddEntity(missile1);
+            var missile2 = new Missile(1) { X = ship.X, Y = ship.Y - 1 };
+            map.AddEntity(missile2);
+
+            var missile3 = new Missile(2) { X = ship.X, Y = ship.Y - 3 };
+            map.AddEntity(missile3);
+            var missile4 = new Missile(2) { X = ship.X, Y = ship.Y - 4 };
+            map.AddEntity(missile4);
+
+            game.Update();
+
+
+            // Then
+            Assert.IsFalse(missile1.Alive, "Missile 1 wasn't destroyed.");
+            Assert.IsFalse(missile3.Alive, "Missile 3 wasn't destroyed.");
+            Assert.IsFalse(missile2.Alive, "Missile 2 wasn't destroyed.");
+            Assert.IsFalse(missile4.Alive, "Missile 4 wasn't destroyed.");
+        }
+
+        [Test]
+        public void TestSamePlayerMissilesDontDestroyEachother2()
+        {
+            // Given
+            var game = Match.GetInstance();
+            game.StartNewGame();
+            var map = game.Map;
+
+            var player = game.GetPlayer(1);
+            var ship = player.Ship;
+            var aliens = game.GetPlayer(2).AlienManager;
+            var player2 = game.GetPlayer(2);
+            var killsBefore = player2.Kills;
+
+            // When
+            //add them in the order the harness would add them
+            var missile1 = new Missile(1) { X = ship.X, Y = ship.Y - 2 };
+            map.AddEntity(missile1);
+            var missile2 = new Missile(1) { X = ship.X, Y = ship.Y - 1 };
+            map.AddEntity(missile2);
+
+            var missile3 = new Missile(2) { X = ship.X, Y = ship.Y - 4 };
+            map.AddEntity(missile3);
+            var missile4 = new Missile(2) { X = ship.X, Y = ship.Y - 5 };
+            map.AddEntity(missile4);
+
+            game.Update();
+
+
+            // Then
+            Assert.IsFalse(missile1.Alive, "Missile 1 wasn't destroyed.");
+            Assert.IsFalse(missile3.Alive, "Missile 3 wasn't destroyed.");
+            Assert.IsTrue(missile2.Alive, "Missile 2 was destroyed.");
+            Assert.IsTrue(missile4.Alive, "Missile 4 was destroyed.");
+            game.Update();
+            Assert.IsFalse(missile2.Alive, "Missile 2 wasn't destroyed.");
+            Assert.IsFalse(missile4.Alive, "Missile 4 wasn't destroyed.");
+        }
+
+        [Test]
+        public void TestSamePlayerMissilesDontDestroyEachother3()
+        {
+            // Given
+            var game = Match.GetInstance();
+            game.StartNewGame();
+            var map = game.Map;
+
+            var player = game.GetPlayer(1);
+            var ship = player.Ship;
+            var aliens = game.GetPlayer(2).AlienManager;
+            var player2 = game.GetPlayer(2);
+            var killsBefore = player2.Kills;
+
+            // When
+            //add them in the order the harness would add them
+            var missile1 = new Missile(1) { X = ship.X, Y = ship.Y - 2 };
+            map.AddEntity(missile1);
+            var missile2 = new Missile(1) { X = ship.X, Y = ship.Y - 1 };
+            map.AddEntity(missile2);
+
+            var missile3 = new Missile(2) { X = ship.X, Y = ship.Y - 4 };
+            map.AddEntity(missile3);
+
+            game.Update();
+
+
+            // Then
+            Assert.IsFalse(missile1.Alive, "Missile 1 wasn't destroyed.");
+            Assert.IsFalse(missile3.Alive, "Missile 3 wasn't destroyed.");
+            Assert.IsTrue(missile2.Alive, "Missile 2 was destroyed.");
+            game.Update();
+            Assert.IsTrue(missile2.Alive, "Missile 2 was destroyed.");
+        }
+
+        [Test]
+        public void TestSamePlayerMissilesDontDestroyEachother4()
+        {
+            // Given
+            var game = Match.GetInstance();
+            game.StartNewGame();
+            var map = game.Map;
+
+            var player = game.GetPlayer(1);
+            var ship = player.Ship;
+            var aliens = game.GetPlayer(2).AlienManager;
+            var player2 = game.GetPlayer(2);
+            var killsBefore = player2.Kills;
+
+            // When
+            //add them in the order the harness would add them
+            var missile1 = new Missile(1) { X = ship.X, Y = ship.Y - 2 };
+            map.AddEntity(missile1);
+
+            var missile3 = new Missile(2) { X = ship.X, Y = ship.Y - 4 };
+            map.AddEntity(missile3);
+            var missile4 = new Missile(2) { X = ship.X, Y = ship.Y - 5 };
+            map.AddEntity(missile4);
+
+            game.Update();
+
+
+            // Then
+            Assert.IsFalse(missile1.Alive, "Missile 1 wasn't destroyed.");
+            Assert.IsFalse(missile3.Alive, "Missile 3 wasn't destroyed.");
+            Assert.IsTrue(missile4.Alive, "Missile 4 was destroyed.");
+            game.Update();
+            Assert.IsTrue(missile4.Alive, "Missile 4 was destroyed.");
+        }
+
+        [Test]
+        public void TestMissilesPassThroughKillEachother()
+        {
+            // Given
+            var game = Match.GetInstance();
+            game.StartNewGame();
+            var map = game.Map;
+
+            var player = game.GetPlayer(1);
+            var ship = player.Ship;
+            var aliens = game.GetPlayer(2).AlienManager;
+            var player2 = game.GetPlayer(2);
+            var killsBefore = player2.Kills;
+
+            // When
+            //add them in the order the harness would add them
+            var missile1 = new Missile(1) { X = ship.X, Y = ship.Y - 3 };
+            map.AddEntity(missile1);
+
+            var missile3 = new Missile(2) { X = ship.X, Y = ship.Y - 4 };
+            map.AddEntity(missile3);
+
+            game.Update();
+
+
+            // Then
+            Assert.IsFalse(missile1.Alive, "Missile 1 wasn't destroyed.");
+            Assert.IsFalse(missile3.Alive, "Missile 3 wasn't destroyed.");
+        }
+
+
+        [Test]
         public void TestShipMovingLeftIntoBulletDies()
         {
             // Given


### PR DESCRIPTION
Fixed the missile collision bug where player missiles hitting an object (alien or shield) simultaneously don't get destroyed. Fixed bug where respawing ship only destroys 1 of the objects it's colliding with. Fixed bug where ships attempting to move into aliens/missiles/bullets fail to move and survive (as pointed out by rm2k, the rules specifically mention this case "Moving into bullets, aliens or missiles will destroy your ship. Moving into a wall will do nothing"). Added several test cases.
